### PR TITLE
fix: install Jinja2 v2 to work well with Flex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pelican>=4.7,<4.8
 Markdown
 ghp-import
 beautifulsoup4
+jinja2<3


### PR DESCRIPTION
Flex v2.4.0 is still using the `JINJA_EXTENSIONS` variable in settings, while Pelican 4.7 deprecated it. It should be fixed in Flex v2.5 (alexandrevicenzi/Flex#268, alexandrevicenzi/Flex@e04a961).

With Jinja2 v2, this variable is not needed in settings, but it is required with Jinja2 v3.