### PR TITLE
build: update Pelican to 4.8

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- #
-from __future__ import unicode_literals
 from datetime import datetime
 
 

--- a/publishconf.py
+++ b/publishconf.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- #
-from __future__ import unicode_literals
-
 # This file is only used if you use `make publish` or
 # explicitly specify it as your config file.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-pelican>=4.7,<4.8
+pelican>=4.8,<4.9
 Markdown
 ghp-import
 beautifulsoup4
-jinja2<3
-MarkupSafe<2.1

--- a/tasks.py
+++ b/tasks.py
@@ -93,7 +93,7 @@ def livereload(c):
     from livereload import Server
 
     def cached_build():
-        cmd = '-s {settings_base} -e CACHE_CONTENT=True LOAD_CONTENT_CACHE=True'
+        cmd = '-s {settings_base} -e CACHE_CONTENT=true LOAD_CONTENT_CACHE=true'
         pelican_run(cmd.format(**CONFIG))
 
     cached_build()


### PR DESCRIPTION
The two requirements constraints (`jinja2` and `markupsafe`) are not necessary anymore.

The changelog for Pelican 4.8 is available: https://docs.getpelican.com/en/4.8.0/changelog.html#id1.